### PR TITLE
Issue #3 ガイドアプリのシェルを実装

### DIFF
--- a/WInUISample/MainWindow.xaml
+++ b/WInUISample/MainWindow.xaml
@@ -3,7 +3,6 @@
     x:Class="WinUISample.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WinUISample"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
@@ -13,6 +12,41 @@
         <MicaBackdrop />
     </Window.SystemBackdrop>
 
-    <Grid>
-    </Grid>
+    <NavigationView
+        x:Name="GuideNavigationView"
+        Header="アプリ構造"
+        IsBackButtonVisible="Collapsed"
+        IsSettingsVisible="False"
+        PaneTitle="WinUI 3 ガイド"
+        SelectionChanged="GuideNavigationView_SelectionChanged">
+        <NavigationView.MenuItems>
+            <NavigationViewItem
+                x:Name="AppStructureNavigationItem"
+                Content="アプリ構造"
+                Icon="Home"
+                Tag="AppStructure" />
+            <NavigationViewItem
+                Content="ナビゲーション"
+                Icon="Forward"
+                Tag="Navigation" />
+            <NavigationViewItem
+                Content="ダイアログ"
+                Icon="Message"
+                Tag="Dialogs" />
+            <NavigationViewItem
+                Content="レイアウト"
+                Icon="ViewAll"
+                Tag="Layout" />
+            <NavigationViewItem
+                Content="スタイリング"
+                Icon="Edit"
+                Tag="Styling" />
+            <NavigationViewItem
+                Content="アプリ外観"
+                Icon="OutlineStar"
+                Tag="AppAppearance" />
+        </NavigationView.MenuItems>
+
+        <Frame x:Name="ContentFrame" />
+    </NavigationView>
 </Window>

--- a/WInUISample/MainWindow.xaml.cs
+++ b/WInUISample/MainWindow.xaml.cs
@@ -1,18 +1,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using System.Threading.Tasks;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
+using WinUISample.Pages;
 
 namespace WinUISample
 {
@@ -25,26 +14,47 @@ namespace WinUISample
         public MainWindow()
         {
             InitializeComponent();
+            GuideNavigationView.SelectedItem = AppStructureNavigationItem;
+            NavigateToPage(AppStructureNavigationItem);
         }
         #endregion
 
-        #region HelloButton_Click : HelloButton のクリックイベントハンドラー
+        #region GuideNavigationView_SelectionChanged : 章選択時のイベントハンドラー
         /// <summary>
-        /// HelloButton のクリックイベントハンドラー
+        /// 章選択時のイベントハンドラー
         /// </summary>
-        private async void HelloButton_Click(object sender, RoutedEventArgs e)
+        private void GuideNavigationView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
         {
-            // WinUI では、MessageBox は存在しないため、ContentDialog を使用してメッセージを表示します。
-            var dialog = new ContentDialog()
+            if (args.SelectedItem is NavigationViewItem selectedItem)
             {
-                Title = "Hello, WinUI!",
-                Content = "This is a message from the button click event.",
-                PrimaryButtonText = "Yes",
-                SecondaryButtonText = "No",
-                CloseButtonText = "Cancel",
-                XamlRoot = Content.XamlRoot,
+                NavigateToPage(selectedItem);
+            }
+        }
+        #endregion
+
+        #region NavigateToPage : 選択された章へ遷移
+        /// <summary>
+        /// 選択された章へ遷移します。
+        /// </summary>
+        private void NavigateToPage(NavigationViewItem selectedItem)
+        {
+            var pageType = selectedItem.Tag switch
+            {
+                "AppStructure" => typeof(AppStructurePage),
+                "Navigation" => typeof(NavigationPage),
+                "Dialogs" => typeof(DialogsPage),
+                "Layout" => typeof(LayoutPage),
+                "Styling" => typeof(StylingPage),
+                "AppAppearance" => typeof(AppAppearancePage),
+                _ => typeof(AppStructurePage),
             };
-            _ = dialog.ShowAsync();
+
+            GuideNavigationView.Header = selectedItem.Content;
+
+            if (ContentFrame.CurrentSourcePageType != pageType)
+            {
+                ContentFrame.Navigate(pageType);
+            }
         }
         #endregion
     }

--- a/WInUISample/Pages/AppAppearancePage.xaml
+++ b/WInUISample/Pages/AppAppearancePage.xaml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WinUISample.Pages.AppAppearancePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <ScrollViewer>
+        <StackPanel Spacing="12" Padding="32">
+            <TextBlock Text="アプリ外観" Style="{ThemeResource TitleTextBlockStyle}" />
+            <TextBlock Text="Mica、タイトルバー、テーマなど、アプリ全体の見た目を整理する章です。" TextWrapping="Wrap" />
+            <TextBlock Text="この章の詳細なガイドは今後の Issue で実装します。" TextWrapping="Wrap" />
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/WInUISample/Pages/AppAppearancePage.xaml.cs
+++ b/WInUISample/Pages/AppAppearancePage.xaml.cs
@@ -1,0 +1,19 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace WinUISample.Pages;
+
+/// <summary>
+/// アプリ外観章のページです。
+/// </summary>
+public sealed partial class AppAppearancePage : Page
+{
+    #region Constructor
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    public AppAppearancePage()
+    {
+        InitializeComponent();
+    }
+    #endregion
+}

--- a/WInUISample/Pages/AppStructurePage.xaml
+++ b/WInUISample/Pages/AppStructurePage.xaml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WinUISample.Pages.AppStructurePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <ScrollViewer>
+        <StackPanel Spacing="12" Padding="32">
+            <TextBlock Text="アプリ構造" Style="{ThemeResource TitleTextBlockStyle}" />
+            <TextBlock Text="WinUI 3 アプリの起動、Window、Page、リソースの関係を整理する章です。" TextWrapping="Wrap" />
+            <TextBlock Text="この章の詳細なガイドは今後の Issue で実装します。" TextWrapping="Wrap" />
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/WInUISample/Pages/AppStructurePage.xaml.cs
+++ b/WInUISample/Pages/AppStructurePage.xaml.cs
@@ -1,0 +1,19 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace WinUISample.Pages;
+
+/// <summary>
+/// アプリ構造章のページです。
+/// </summary>
+public sealed partial class AppStructurePage : Page
+{
+    #region Constructor
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    public AppStructurePage()
+    {
+        InitializeComponent();
+    }
+    #endregion
+}

--- a/WInUISample/Pages/DialogsPage.xaml
+++ b/WInUISample/Pages/DialogsPage.xaml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WinUISample.Pages.DialogsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <ScrollViewer>
+        <StackPanel Spacing="12" Padding="32">
+            <TextBlock Text="ダイアログ" Style="{ThemeResource TitleTextBlockStyle}" />
+            <TextBlock Text="ContentDialog など、WinUI 3 のダイアログ表示を整理する章です。" TextWrapping="Wrap" />
+            <TextBlock Text="この章の詳細なガイドは今後の Issue で実装します。" TextWrapping="Wrap" />
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/WInUISample/Pages/DialogsPage.xaml.cs
+++ b/WInUISample/Pages/DialogsPage.xaml.cs
@@ -1,0 +1,19 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace WinUISample.Pages;
+
+/// <summary>
+/// ダイアログ章のページです。
+/// </summary>
+public sealed partial class DialogsPage : Page
+{
+    #region Constructor
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    public DialogsPage()
+    {
+        InitializeComponent();
+    }
+    #endregion
+}

--- a/WInUISample/Pages/LayoutPage.xaml
+++ b/WInUISample/Pages/LayoutPage.xaml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WinUISample.Pages.LayoutPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <ScrollViewer>
+        <StackPanel Spacing="12" Padding="32">
+            <TextBlock Text="レイアウト" Style="{ThemeResource TitleTextBlockStyle}" />
+            <TextBlock Text="Grid、StackPanel、レスポンシブな配置などを整理する章です。" TextWrapping="Wrap" />
+            <TextBlock Text="この章の詳細なガイドは今後の Issue で実装します。" TextWrapping="Wrap" />
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/WInUISample/Pages/LayoutPage.xaml.cs
+++ b/WInUISample/Pages/LayoutPage.xaml.cs
@@ -1,0 +1,19 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace WinUISample.Pages;
+
+/// <summary>
+/// レイアウト章のページです。
+/// </summary>
+public sealed partial class LayoutPage : Page
+{
+    #region Constructor
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    public LayoutPage()
+    {
+        InitializeComponent();
+    }
+    #endregion
+}

--- a/WInUISample/Pages/NavigationPage.xaml
+++ b/WInUISample/Pages/NavigationPage.xaml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WinUISample.Pages.NavigationPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <ScrollViewer>
+        <StackPanel Spacing="12" Padding="32">
+            <TextBlock Text="ナビゲーション" Style="{ThemeResource TitleTextBlockStyle}" />
+            <TextBlock Text="NavigationView と Frame を使った画面遷移を整理する章です。" TextWrapping="Wrap" />
+            <TextBlock Text="この章の詳細なガイドは今後の Issue で実装します。" TextWrapping="Wrap" />
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/WInUISample/Pages/NavigationPage.xaml.cs
+++ b/WInUISample/Pages/NavigationPage.xaml.cs
@@ -1,0 +1,19 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace WinUISample.Pages;
+
+/// <summary>
+/// ナビゲーション章のページです。
+/// </summary>
+public sealed partial class NavigationPage : Page
+{
+    #region Constructor
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    public NavigationPage()
+    {
+        InitializeComponent();
+    }
+    #endregion
+}

--- a/WInUISample/Pages/StylingPage.xaml
+++ b/WInUISample/Pages/StylingPage.xaml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WinUISample.Pages.StylingPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <ScrollViewer>
+        <StackPanel Spacing="12" Padding="32">
+            <TextBlock Text="スタイリング" Style="{ThemeResource TitleTextBlockStyle}" />
+            <TextBlock Text="ThemeResource、Style、テンプレートなどを整理する章です。" TextWrapping="Wrap" />
+            <TextBlock Text="この章の詳細なガイドは今後の Issue で実装します。" TextWrapping="Wrap" />
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/WInUISample/Pages/StylingPage.xaml.cs
+++ b/WInUISample/Pages/StylingPage.xaml.cs
@@ -1,0 +1,19 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace WinUISample.Pages;
+
+/// <summary>
+/// スタイリング章のページです。
+/// </summary>
+public sealed partial class StylingPage : Page
+{
+    #region Constructor
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    public StylingPage()
+    {
+        InitializeComponent();
+    }
+    #endregion
+}


### PR DESCRIPTION
## 対応内容
- NavigationView + Frame によるアプリシェルを実装
- 章一覧から各プレースホルダーページへ遷移できるように対応
- 起動時にアプリ構造ページを初期表示
- 未使用のサンプルボタン処理を整理

## 確認
- dotnet build C:\Users\keigo\source\repos\WinUISample\WinUISample.slnx -p:Platform=x64 -p:Configuration=Debug

Closes #3