### PR TITLE
Implement WPF getting started guide

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,9 +20,8 @@
         {
             "label": "MSIXパッケージを登録して起動",
             "type": "shell",
-            "command": "Add-AppxPackage -Register -ForceApplicationShutdown '${workspaceFolder}/WinUISample/bin/x64/Debug/net8.0-windows10.0.19041.0/win-x64/AppX/AppxManifest.xml'; Start-Process 'explorer.exe' 'shell:AppsFolder\\30fb9632-0ca3-4b46-b553-f1c909f0766e_ze6ep6tpmmkp8!App'; Start-Sleep 3",
-            "dependsOn": "ビルド",
-            "problemMatcher": []
+            "command": "dotnet build '${workspaceFolder}/WinUISample/WinUISample.csproj' /p:Platform=x64 /p:Configuration=Debug; if ($LASTEXITCODE -eq 0) { Add-AppxPackage -Register -ForceApplicationShutdown '${workspaceFolder}/WinUISample/bin/x64/Debug/net8.0-windows10.0.19041.0/win-x64/AppX/AppxManifest.xml'; Start-Process 'explorer.exe' 'shell:AppsFolder\\30fb9632-0ca3-4b46-b553-f1c909f0766e_ze6ep6tpmmkp8!App'; Start-Sleep 3 } else { throw 'ビルドに失敗しました' }",
+            "problemMatcher": "$msCompile"
         }
     ]
 }

--- a/WInUISample/MainWindow.xaml
+++ b/WInUISample/MainWindow.xaml
@@ -21,6 +21,11 @@
         SelectionChanged="GuideNavigationView_SelectionChanged">
         <NavigationView.MenuItems>
             <NavigationViewItem
+                x:Name="GettingStartedNavigationItem"
+                Content="はじめに"
+                Icon="Home"
+                Tag="GettingStarted" />
+            <NavigationViewItem
                 x:Name="AppStructureNavigationItem"
                 Content="アプリ構造"
                 Icon="Home"

--- a/WInUISample/MainWindow.xaml.cs
+++ b/WInUISample/MainWindow.xaml.cs
@@ -14,8 +14,8 @@ namespace WinUISample
         public MainWindow()
         {
             InitializeComponent();
-            GuideNavigationView.SelectedItem = AppStructureNavigationItem;
-            NavigateToPage(AppStructureNavigationItem);
+            GuideNavigationView.SelectedItem = GettingStartedNavigationItem;
+            NavigateToPage(GettingStartedNavigationItem);
         }
         #endregion
 
@@ -40,13 +40,14 @@ namespace WinUISample
         {
             var pageType = selectedItem.Tag switch
             {
+                "GettingStarted" => typeof(GettingStartedPage),
                 "AppStructure" => typeof(AppStructurePage),
                 "Navigation" => typeof(NavigationPage),
                 "Dialogs" => typeof(DialogsPage),
                 "Layout" => typeof(LayoutPage),
                 "Styling" => typeof(StylingPage),
                 "AppAppearance" => typeof(AppAppearancePage),
-                _ => typeof(AppStructurePage),
+                _ => typeof(GettingStartedPage),
             };
 
             GuideNavigationView.Header = selectedItem.Content;

--- a/WInUISample/Pages/GettingStartedPage.xaml
+++ b/WInUISample/Pages/GettingStartedPage.xaml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WinUISample.Pages.GettingStartedPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <ScrollViewer>
+        <StackPanel
+            MaxWidth="960"
+            Padding="32"
+            HorizontalAlignment="Left"
+            Spacing="24">
+            <StackPanel Spacing="8">
+                <TextBlock Text="WPF 経験者向け WinUI 3 初回ガイド" Style="{ThemeResource TitleTextBlockStyle}" />
+                <TextBlock
+                    Text="WPF の App、Window、Page、Frame の知識を出発点に、WinUI 3 アプリの入口と画面遷移の関係を確認します。"
+                    TextWrapping="Wrap" />
+            </StackPanel>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="WPF と WinUI 3 の対応関係" FontSize="22" FontWeight="SemiBold" />
+                <Grid ColumnSpacing="16" RowSpacing="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="180" />
+                        <ColumnDefinition Width="220" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="WPF" FontWeight="SemiBold" />
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="WinUI 3" FontWeight="SemiBold" />
+                    <TextBlock Grid.Row="0" Grid.Column="2" Text="役割" FontWeight="SemiBold" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="App.xaml / App.xaml.cs" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="App.xaml / App.xaml.cs" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="1" Grid.Column="2" Text="アプリ起動時の共通リソースと、最初に開く Window を準備します。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Window" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="Window" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="2" Grid.Column="2" Text="デスクトップアプリの最上位ウィンドウです。WinUI 3 では MainWindow が NavigationView と Frame を保持します。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Page" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="3" Grid.Column="1" Text="Page" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="3" Grid.Column="2" Text="画面単位の UI です。章ごとの説明やサンプルを Page として分けます。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Frame" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="4" Grid.Column="1" Text="Frame" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="4" Grid.Column="2" Text="Page を差し替える表示領域です。NavigationView の選択に応じて Frame.Navigate で遷移します。" TextWrapping="Wrap" />
+                </Grid>
+            </StackPanel>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="NavigationView が担う役割" FontSize="22" FontWeight="SemiBold" />
+                <TextBlock
+                    Text="このサンプルでは MainWindow がアプリシェルです。左側の NavigationView が章の一覧を表示し、中央の Frame に選択された Page を表示します。WPF のメニューやナビゲーション領域を、WinUI 3 の標準的なシェル構成に置き換えた形です。"
+                    TextWrapping="Wrap" />
+            </StackPanel>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="MessageBox から ContentDialog へ" FontSize="22" FontWeight="SemiBold" />
+                <TextBlock
+                    Text="WPF では MessageBox.Show で簡単な確認ダイアログを表示できます。WinUI 3 では ContentDialog を作成し、表示先の XamlRoot を設定してから非同期で表示します。"
+                    TextWrapping="Wrap" />
+                <Button
+                    Content="ContentDialog を表示"
+                    Click="ShowContentDialogButton_Click" />
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/WInUISample/Pages/GettingStartedPage.xaml.cs
+++ b/WInUISample/Pages/GettingStartedPage.xaml.cs
@@ -1,0 +1,41 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System;
+
+namespace WinUISample.Pages;
+
+/// <summary>
+/// WPF 経験者向け初回ガイドページです。
+/// </summary>
+public sealed partial class GettingStartedPage : Page
+{
+    #region Constructor
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    public GettingStartedPage()
+    {
+        InitializeComponent();
+    }
+    #endregion
+
+    #region ShowContentDialogButton_Click : ContentDialog 表示ボタン押下時のイベントハンドラー
+    /// <summary>
+    /// ContentDialog 表示ボタン押下時のイベントハンドラー
+    /// </summary>
+    private async void ShowContentDialogButton_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new ContentDialog
+        {
+            Title = "ContentDialog のサンプル",
+            Content = "WinUI 3 では、ContentDialog に XamlRoot を設定して現在の画面上に表示します。",
+            PrimaryButtonText = "OK",
+            CloseButtonText = "閉じる",
+            DefaultButton = ContentDialogButton.Primary,
+            XamlRoot = XamlRoot,
+        };
+
+        await dialog.ShowAsync();
+    }
+    #endregion
+}


### PR DESCRIPTION
## 対応内容

- WPF 経験者向けの初回ガイドページを追加
- 起動直後の初期表示を初回ガイドページへ変更
- WPF / WinUI 3 の App、Window、Page、Frame の対応関係を画面上に追加
- MessageBox の代替として ContentDialog を表示できるサンプルを追加

## 確認

- `dotnet build .\WinUISample.slnx -p:Platform=x64 -p:Configuration=Debug`

Closes #4