### PR TITLE
Remove unused MainWindow handler remnants

### DIFF
--- a/WInUISample/MainWindow.xaml.cs
+++ b/WInUISample/MainWindow.xaml.cs
@@ -1,6 +1,5 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
 using WinUISample.Pages;
 
 namespace WinUISample


### PR DESCRIPTION
## Summary
- Remove the remaining unused `System` using from `MainWindow.xaml.cs` after `HelloButton_Click` was moved out of `MainWindow`.
- Confirm that `HelloButton_Click` no longer exists and the remaining click handler is connected from XAML.
- Posted the same-pattern investigation result to Issue #5.

Fixes #5