### PR TITLE
Issue #6 manifest capability と publish profile の設定整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,9 @@ publish/
 
 # Publish Web Output
 *.[Pp]ubxml
+# このアプリの MSIX 発行プロファイルはプロジェクト設定として管理する
+!WInUISample/Properties/PublishProfiles/
+!WInUISample/Properties/PublishProfiles/*.pubxml
 # Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml.user

--- a/WInUISample/Package.appxmanifest
+++ b/WInUISample/Package.appxmanifest
@@ -4,9 +4,7 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  xmlns:systemai="http://schemas.microsoft.com/appx/manifest/systemai/windows10"
-  IgnorableNamespaces="uap rescap systemai">
+  IgnorableNamespaces="uap">
 
   <Identity
     Name="30fb9632-0ca3-4b46-b553-f1c909f0766e"
@@ -16,7 +14,7 @@
   <mp:PhoneIdentity PhoneProductId="30fb9632-0ca3-4b46-b553-f1c909f0766e" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 
   <Properties>
-    <DisplayName>WinUISample</DisplayName>
+    <DisplayName>WinUI 3 ガイド</DisplayName>
     <PublisherDisplayName>keigo</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
@@ -35,8 +33,8 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="WinUISample"
-        Description="WinUISample"
+        DisplayName="WinUI 3 ガイド"
+        Description="WPF 経験者向けに WinUI 3 の基本を確認できるガイド アプリです。"
         BackgroundColor="transparent"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png">
@@ -46,8 +44,4 @@
     </Application>
   </Applications>
 
-  <Capabilities>
-    <rescap:Capability Name="runFullTrust" />
-    <systemai:Capability Name="systemAIModels"/>
-  </Capabilities>
 </Package>

--- a/WInUISample/Properties/PublishProfiles/win-arm64.pubxml
+++ b/WInUISample/Properties/PublishProfiles/win-arm64.pubxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\win-arm64\publish\</PublishDir>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+</Project>

--- a/WInUISample/Properties/PublishProfiles/win-x64.pubxml
+++ b/WInUISample/Properties/PublishProfiles/win-x64.pubxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\win-x64\publish\</PublishDir>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+</Project>

--- a/WInUISample/Properties/PublishProfiles/win-x86.pubxml
+++ b/WInUISample/Properties/PublishProfiles/win-x86.pubxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\win-x86\publish\</PublishDir>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+</Project>

--- a/WInUISample/WinUISample.csproj
+++ b/WInUISample/WinUISample.csproj
@@ -7,7 +7,9 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <PublishProfile Condition="'$(Platform)' == 'x86'">win-x86.pubxml</PublishProfile>
+    <PublishProfile Condition="'$(Platform)' == 'x64'">win-x64.pubxml</PublishProfile>
+    <PublishProfile Condition="'$(Platform)' == 'ARM64'">win-arm64.pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <WinUISDKReferences>false</WinUISDKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>


### PR DESCRIPTION
## 対応内容

- `Package.appxmanifest` の表示名を `WinUI 3 ガイド`、説明を WPF 経験者向けガイドアプリとして更新しました。
- 未使用の `runFullTrust` / `systemAIModels` capability と関連 namespace を削除しました。
- `x86` / `x64` / `ARM64` に対応する publish profile を追加し、`WinUISample.csproj` の `PublishProfile` を Platform ごとに明示しました。
- publish profile をリポジトリ管理できるよう、このプロジェクトの `PublishProfiles/*.pubxml` だけ `.gitignore` の除外から外しました。

## 確認

- `dotnet build .\WinUISample.slnx -p:Platform=x64 -p:Configuration=Debug --nologo`
- `dotnet build .\WinUISample.slnx -p:Platform=x86 -p:Configuration=Debug --nologo`
- `dotnet build .\WinUISample.slnx -p:Platform=ARM64 -p:Configuration=Debug --nologo`
- `dotnet publish .\WInUISample\WinUISample.csproj -p:Platform=x64 -p:Configuration=Debug --nologo --no-restore`

Closes #6