### PR TITLE
Implement WinUI guide pages

### DIFF
--- a/WInUISample/App.xaml
+++ b/WInUISample/App.xaml
@@ -8,9 +8,41 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-                <!-- Other merged dictionaries here -->
+                <!-- WinUI 標準コントロールのテーマリソースを読み込みます。 -->
             </ResourceDictionary.MergedDictionaries>
-            <!-- Other app resources here -->
+
+            <Style x:Key="GuideContentStackPanelStyle" TargetType="StackPanel">
+                <Setter Property="MaxWidth" Value="960" />
+                <Setter Property="Padding" Value="32" />
+                <Setter Property="HorizontalAlignment" Value="Left" />
+                <Setter Property="Spacing" Value="24" />
+            </Style>
+
+            <Style x:Key="GuideSectionHeadingTextBlockStyle" TargetType="TextBlock">
+                <Setter Property="FontSize" Value="22" />
+                <Setter Property="FontWeight" Value="SemiBold" />
+                <Setter Property="TextWrapping" Value="Wrap" />
+            </Style>
+
+            <Style x:Key="GuideSubHeadingTextBlockStyle" TargetType="TextBlock">
+                <Setter Property="FontSize" Value="18" />
+                <Setter Property="FontWeight" Value="SemiBold" />
+                <Setter Property="TextWrapping" Value="Wrap" />
+            </Style>
+
+            <Style x:Key="GuideCardBorderStyle" TargetType="Border">
+                <Setter Property="Padding" Value="16" />
+                <Setter Property="CornerRadius" Value="8" />
+                <Setter Property="Background" Value="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
+                <Setter Property="BorderBrush" Value="{ThemeResource CardStrokeColorDefaultBrush}" />
+                <Setter Property="BorderThickness" Value="1" />
+            </Style>
+
+            <Style x:Key="GuideCodeTextBlockStyle" TargetType="TextBlock">
+                <Setter Property="FontFamily" Value="Consolas" />
+                <Setter Property="TextWrapping" Value="Wrap" />
+                <Setter Property="IsTextSelectionEnabled" Value="True" />
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/WInUISample/App.xaml.cs
+++ b/WInUISample/App.xaml.cs
@@ -7,7 +7,10 @@ namespace WinUISample
     /// </summary>
     public partial class App : Application
     {
-        private Window? _window;
+        /// <summary>
+        /// 現在表示しているメインウィンドウです。
+        /// </summary>
+        public static Window? MainWindow { get; private set; }
 
         /// <summary>
         /// アプリケーションのシングルトンインスタンスを初期化します。
@@ -23,8 +26,8 @@ namespace WinUISample
         /// <param name="args">起動要求の情報です。</param>
         protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
         {
-            _window = new MainWindow();
-            _window.Activate();
+            MainWindow = new MainWindow();
+            MainWindow.Activate();
         }
     }
 }

--- a/WInUISample/App.xaml.cs
+++ b/WInUISample/App.xaml.cs
@@ -1,36 +1,16 @@
 ﻿using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
-using Microsoft.UI.Xaml.Shapes;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.ApplicationModel;
-using Windows.ApplicationModel.Activation;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace WinUISample
 {
     /// <summary>
-    /// Provides application-specific behavior to supplement the default Application class.
+    /// アプリ全体の起動処理と共通動作を管理します。
     /// </summary>
     public partial class App : Application
     {
         private Window? _window;
 
         /// <summary>
-        /// Initializes the singleton application object.  This is the first line of authored code
-        /// executed, and as such is the logical equivalent of main() or WinMain().
+        /// アプリケーションのシングルトンインスタンスを初期化します。
         /// </summary>
         public App()
         {
@@ -38,9 +18,9 @@ namespace WinUISample
         }
 
         /// <summary>
-        /// Invoked when the application is launched.
+        /// アプリ起動時にメインウィンドウを作成して表示します。
         /// </summary>
-        /// <param name="args">Details about the launch request and process.</param>
+        /// <param name="args">起動要求の情報です。</param>
         protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
         {
             _window = new MainWindow();

--- a/WInUISample/MainWindow.xaml
+++ b/WInUISample/MainWindow.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="WinUISample">
+    Title="WinUI 3 ガイド">
 
     <Window.SystemBackdrop>
         <MicaBackdrop />

--- a/WInUISample/Pages/AppAppearancePage.xaml
+++ b/WInUISample/Pages/AppAppearancePage.xaml
@@ -16,8 +16,75 @@
                     TextWrapping="Wrap" />
             </StackPanel>
 
+            <Border Style="{StaticResource GuideCardBorderStyle}">
+                <StackPanel Spacing="14">
+                    <StackPanel Spacing="6">
+                        <TextBlock Text="外観を直接変更する" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                        <TextBlock
+                            Text="下の設定を変えると、現在表示しているアプリのテーマ、背景素材、ウィンドウタイトルへそのまま反映されます。"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+
+                    <Grid ColumnSpacing="16" RowSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="170" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="テーマ" FontWeight="SemiBold" VerticalAlignment="Center" />
+                        <ComboBox
+                            x:Name="ThemeComboBox"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            MinWidth="220"
+                            HorizontalAlignment="Left"
+                            SelectionChanged="ThemeComboBox_SelectionChanged">
+                            <ComboBoxItem Content="システム設定に従う" Tag="Default" />
+                            <ComboBoxItem Content="ライト" Tag="Light" />
+                            <ComboBoxItem Content="ダーク" Tag="Dark" />
+                        </ComboBox>
+
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="背景素材" FontWeight="SemiBold" VerticalAlignment="Center" />
+                        <ComboBox
+                            x:Name="BackdropComboBox"
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            MinWidth="220"
+                            HorizontalAlignment="Left"
+                            SelectionChanged="BackdropComboBox_SelectionChanged">
+                            <ComboBoxItem Content="Mica" Tag="Mica" />
+                            <ComboBoxItem Content="Acrylic" Tag="Acrylic" />
+                            <ComboBoxItem Content="なし" Tag="None" />
+                        </ComboBox>
+
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="タイトル" FontWeight="SemiBold" VerticalAlignment="Center" />
+                        <StackPanel Grid.Row="2" Grid.Column="1" Spacing="8">
+                            <TextBox
+                                x:Name="WindowTitleTextBox"
+                                Width="260"
+                                MaxWidth="320"
+                                HorizontalAlignment="Left"
+                                PlaceholderText="ウィンドウタイトル" />
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <Button Content="適用" Click="ApplyTitleButton_Click" />
+                                <Button Content="初期値に戻す" Click="ResetAppearanceButton_Click" />
+                            </StackPanel>
+                        </StackPanel>
+                    </Grid>
+
+                    <TextBlock
+                        x:Name="AppearanceResultTextBlock"
+                        TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
+
             <StackPanel Spacing="12">
-                <TextBlock Text="外観を決める主な場所" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <TextBlock Text="このページで変更している場所" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
                 <Grid ColumnSpacing="16" RowSpacing="10">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="190" />
@@ -31,24 +98,24 @@
                     </Grid.RowDefinitions>
 
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="MicaBackdrop" FontWeight="SemiBold" TextWrapping="Wrap" />
-                    <TextBlock Grid.Row="0" Grid.Column="1" Text="Window.SystemBackdrop に設定する背景素材です。このサンプルでは MainWindow.xaml で MicaBackdrop を使っています。" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="Window.SystemBackdrop に設定する背景素材です。このページでは Mica、Acrylic、なしを切り替えます。" TextWrapping="Wrap" />
 
                     <TextBlock Grid.Row="1" Grid.Column="0" Text="タイトルバー" FontWeight="SemiBold" TextWrapping="Wrap" />
-                    <TextBlock Grid.Row="1" Grid.Column="1" Text="Window の Title や AppWindow 関連 API で調整します。独自タイトルバーを作る場合はドラッグ領域やボタン領域も考慮します。" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="Window.Title に設定した文字列が OS のタイトルバーやタスク一覧に表示されます。" TextWrapping="Wrap" />
 
                     <TextBlock Grid.Row="2" Grid.Column="0" Text="アプリアイコン" FontWeight="SemiBold" TextWrapping="Wrap" />
                     <TextBlock Grid.Row="2" Grid.Column="1" Text="Package.appxmanifest の VisualElements と Assets フォルダーの画像が、スタートメニューやタスクバーで使われます。" TextWrapping="Wrap" />
 
                     <TextBlock Grid.Row="3" Grid.Column="0" Text="表示名" FontWeight="SemiBold" TextWrapping="Wrap" />
-                    <TextBlock Grid.Row="3" Grid.Column="1" Text="Package.appxmanifest の DisplayName が、インストール後のアプリ名として表示されます。" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="3" Grid.Column="1" Text="Package.appxmanifest の DisplayName が、インストール後のスタートメニューなどで表示されるアプリ名になります。" TextWrapping="Wrap" />
                 </Grid>
             </StackPanel>
 
             <Border Style="{StaticResource GuideCardBorderStyle}">
                 <StackPanel Spacing="10">
-                    <TextBlock Text="このサンプルで確認できる設定" Style="{StaticResource GuideSubHeadingTextBlockStyle}" />
+                    <TextBlock Text="実装で使っている API" Style="{StaticResource GuideSubHeadingTextBlockStyle}" />
                     <TextBlock
-                        Text="MainWindow.xaml: Window.SystemBackdrop に MicaBackdrop を指定&#x0a;Package.appxmanifest: DisplayName と VisualElements を指定&#x0a;Assets: ロゴやスプラッシュスクリーン画像を配置"
+                        Text="App.MainWindow.SystemBackdrop = new MicaBackdrop()&#x0a;App.MainWindow.SystemBackdrop = new DesktopAcrylicBackdrop()&#x0a;rootElement.RequestedTheme = ElementTheme.Dark&#x0a;App.MainWindow.Title = &quot;WinUI 3 ガイド&quot;"
                         Style="{StaticResource GuideCodeTextBlockStyle}" />
                 </StackPanel>
             </Border>
@@ -59,7 +126,7 @@
                     Text="WPF では WindowStyle、AllowsTransparency、独自 Chrome などでウィンドウ外観を大きく作り込むことができます。WinUI 3 では Windows App SDK のウィンドウ API、標準背景素材、manifest の表示名やロゴ資産を組み合わせて整えます。"
                     TextWrapping="Wrap" />
                 <TextBlock
-                    Text="この Issue では外観設定を直接変更するのではなく、どこを変更すればよいかをガイドページ上で分かる状態にしています。"
+                    Text="このページではテーマや背景素材の変更を現在の Window に直接反映し、manifest で決まる表示名やアイコンとは変更タイミングが違うことも分かるようにしています。"
                     TextWrapping="Wrap" />
             </StackPanel>
         </StackPanel>

--- a/WInUISample/Pages/AppAppearancePage.xaml
+++ b/WInUISample/Pages/AppAppearancePage.xaml
@@ -8,10 +8,60 @@
     mc:Ignorable="d">
 
     <ScrollViewer>
-        <StackPanel Spacing="12" Padding="32">
-            <TextBlock Text="アプリ外観" Style="{ThemeResource TitleTextBlockStyle}" />
-            <TextBlock Text="Mica、タイトルバー、テーマなど、アプリ全体の見た目を整理する章です。" TextWrapping="Wrap" />
-            <TextBlock Text="この章の詳細なガイドは今後の Issue で実装します。" TextWrapping="Wrap" />
+        <StackPanel Style="{StaticResource GuideContentStackPanelStyle}">
+            <StackPanel Spacing="8">
+                <TextBlock Text="アプリ外観" Style="{ThemeResource TitleTextBlockStyle}" />
+                <TextBlock
+                    Text="Mica、タイトルバー、アイコン、manifest 表示名の関係を整理し、WinUI 3 アプリの見た目を調整する入口を確認します。"
+                    TextWrapping="Wrap" />
+            </StackPanel>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="外観を決める主な場所" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <Grid ColumnSpacing="16" RowSpacing="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="190" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="MicaBackdrop" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="Window.SystemBackdrop に設定する背景素材です。このサンプルでは MainWindow.xaml で MicaBackdrop を使っています。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="タイトルバー" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="Window の Title や AppWindow 関連 API で調整します。独自タイトルバーを作る場合はドラッグ領域やボタン領域も考慮します。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="アプリアイコン" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="Package.appxmanifest の VisualElements と Assets フォルダーの画像が、スタートメニューやタスクバーで使われます。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="表示名" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="3" Grid.Column="1" Text="Package.appxmanifest の DisplayName が、インストール後のアプリ名として表示されます。" TextWrapping="Wrap" />
+                </Grid>
+            </StackPanel>
+
+            <Border Style="{StaticResource GuideCardBorderStyle}">
+                <StackPanel Spacing="10">
+                    <TextBlock Text="このサンプルで確認できる設定" Style="{StaticResource GuideSubHeadingTextBlockStyle}" />
+                    <TextBlock
+                        Text="MainWindow.xaml: Window.SystemBackdrop に MicaBackdrop を指定&#x0a;Package.appxmanifest: DisplayName と VisualElements を指定&#x0a;Assets: ロゴやスプラッシュスクリーン画像を配置"
+                        Style="{StaticResource GuideCodeTextBlockStyle}" />
+                </StackPanel>
+            </Border>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="WPF との違い" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <TextBlock
+                    Text="WPF では WindowStyle、AllowsTransparency、独自 Chrome などでウィンドウ外観を大きく作り込むことができます。WinUI 3 では Windows App SDK のウィンドウ API、標準背景素材、manifest の表示名やロゴ資産を組み合わせて整えます。"
+                    TextWrapping="Wrap" />
+                <TextBlock
+                    Text="この Issue では外観設定を直接変更するのではなく、どこを変更すればよいかをガイドページ上で分かる状態にしています。"
+                    TextWrapping="Wrap" />
+            </StackPanel>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/WInUISample/Pages/AppAppearancePage.xaml.cs
+++ b/WInUISample/Pages/AppAppearancePage.xaml.cs
@@ -1,4 +1,6 @@
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 
 namespace WinUISample.Pages;
 
@@ -7,6 +9,9 @@ namespace WinUISample.Pages;
 /// </summary>
 public sealed partial class AppAppearancePage : Page
 {
+    private const string DefaultWindowTitle = "WinUI 3 ガイド";
+    private bool _isInitializing = true;
+
     #region Constructor
     /// <summary>
     /// コンストラクタ
@@ -14,6 +19,207 @@ public sealed partial class AppAppearancePage : Page
     public AppAppearancePage()
     {
         InitializeComponent();
+        InitializeAppearanceControls();
+        _isInitializing = false;
+        UpdateAppearanceResult();
+    }
+    #endregion
+
+    #region InitializeAppearanceControls : 外観設定コントロールを初期化
+    /// <summary>
+    /// 外観設定コントロールを初期化します。
+    /// </summary>
+    private void InitializeAppearanceControls()
+    {
+        WindowTitleTextBox.Text = App.MainWindow?.Title ?? DefaultWindowTitle;
+        ThemeComboBox.SelectedIndex = GetCurrentThemeIndex();
+        BackdropComboBox.SelectedIndex = GetCurrentBackdropIndex();
+    }
+    #endregion
+
+    #region ThemeComboBox_SelectionChanged : テーマ選択時のイベントハンドラー
+    /// <summary>
+    /// テーマ選択時のイベントハンドラー
+    /// </summary>
+    private void ThemeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isInitializing)
+        {
+            return;
+        }
+
+        ApplyTheme();
+    }
+    #endregion
+
+    #region BackdropComboBox_SelectionChanged : 背景素材選択時のイベントハンドラー
+    /// <summary>
+    /// 背景素材選択時のイベントハンドラー
+    /// </summary>
+    private void BackdropComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isInitializing)
+        {
+            return;
+        }
+
+        ApplyBackdrop();
+    }
+    #endregion
+
+    #region ApplyTitleButton_Click : タイトル適用ボタン押下時のイベントハンドラー
+    /// <summary>
+    /// タイトル適用ボタン押下時のイベントハンドラー
+    /// </summary>
+    private void ApplyTitleButton_Click(object sender, RoutedEventArgs e)
+    {
+        ApplyWindowTitle();
+    }
+    #endregion
+
+    #region ResetAppearanceButton_Click : 外観設定初期化ボタン押下時のイベントハンドラー
+    /// <summary>
+    /// 外観設定初期化ボタン押下時のイベントハンドラー
+    /// </summary>
+    private void ResetAppearanceButton_Click(object sender, RoutedEventArgs e)
+    {
+        _isInitializing = true;
+        ThemeComboBox.SelectedIndex = 0;
+        BackdropComboBox.SelectedIndex = 0;
+        WindowTitleTextBox.Text = DefaultWindowTitle;
+        _isInitializing = false;
+
+        ApplyTheme();
+        ApplyBackdrop();
+        ApplyWindowTitle();
+    }
+    #endregion
+
+    #region ApplyTheme : 選択されたテーマを適用
+    /// <summary>
+    /// 選択されたテーマを適用します。
+    /// </summary>
+    private void ApplyTheme()
+    {
+        if (App.MainWindow?.Content is not FrameworkElement rootElement)
+        {
+            return;
+        }
+
+        rootElement.RequestedTheme = GetSelectedTag(ThemeComboBox) switch
+        {
+            "Light" => ElementTheme.Light,
+            "Dark" => ElementTheme.Dark,
+            _ => ElementTheme.Default,
+        };
+
+        UpdateAppearanceResult();
+    }
+    #endregion
+
+    #region ApplyBackdrop : 選択された背景素材を適用
+    /// <summary>
+    /// 選択された背景素材を適用します。
+    /// </summary>
+    private void ApplyBackdrop()
+    {
+        if (App.MainWindow is null)
+        {
+            return;
+        }
+
+        App.MainWindow.SystemBackdrop = GetSelectedTag(BackdropComboBox) switch
+        {
+            "Acrylic" => new DesktopAcrylicBackdrop(),
+            "None" => null,
+            _ => new MicaBackdrop(),
+        };
+
+        UpdateAppearanceResult();
+    }
+    #endregion
+
+    #region ApplyWindowTitle : 入力されたタイトルを適用
+    /// <summary>
+    /// 入力されたタイトルを適用します。
+    /// </summary>
+    private void ApplyWindowTitle()
+    {
+        if (App.MainWindow is null)
+        {
+            return;
+        }
+
+        var title = string.IsNullOrWhiteSpace(WindowTitleTextBox.Text)
+            ? DefaultWindowTitle
+            : WindowTitleTextBox.Text.Trim();
+
+        App.MainWindow.Title = title;
+        WindowTitleTextBox.Text = title;
+        UpdateAppearanceResult();
+    }
+    #endregion
+
+    #region UpdateAppearanceResult : 現在の外観設定表示を更新
+    /// <summary>
+    /// 現在の外観設定表示を更新します。
+    /// </summary>
+    private void UpdateAppearanceResult()
+    {
+        var title = App.MainWindow?.Title ?? DefaultWindowTitle;
+        AppearanceResultTextBlock.Text = $"現在の外観: テーマ = {GetSelectedContent(ThemeComboBox)} / 背景素材 = {GetSelectedContent(BackdropComboBox)} / タイトル = {title}";
+    }
+    #endregion
+
+    #region GetSelectedTag : 選択項目のタグを取得
+    /// <summary>
+    /// 選択項目のタグを取得します。
+    /// </summary>
+    private static string? GetSelectedTag(ComboBox comboBox)
+    {
+        return (comboBox.SelectedItem as ComboBoxItem)?.Tag?.ToString();
+    }
+    #endregion
+
+    #region GetCurrentThemeIndex : 現在のテーマ選択位置を取得
+    /// <summary>
+    /// 現在のテーマ選択位置を取得します。
+    /// </summary>
+    private static int GetCurrentThemeIndex()
+    {
+        return App.MainWindow?.Content is FrameworkElement rootElement
+            ? rootElement.RequestedTheme switch
+            {
+                ElementTheme.Light => 1,
+                ElementTheme.Dark => 2,
+                _ => 0,
+            }
+            : 0;
+    }
+    #endregion
+
+    #region GetCurrentBackdropIndex : 現在の背景素材選択位置を取得
+    /// <summary>
+    /// 現在の背景素材選択位置を取得します。
+    /// </summary>
+    private static int GetCurrentBackdropIndex()
+    {
+        return App.MainWindow?.SystemBackdrop switch
+        {
+            DesktopAcrylicBackdrop => 1,
+            null => 2,
+            _ => 0,
+        };
+    }
+    #endregion
+
+    #region GetSelectedContent : 選択項目の表示名を取得
+    /// <summary>
+    /// 選択項目の表示名を取得します。
+    /// </summary>
+    private static string GetSelectedContent(ComboBox comboBox)
+    {
+        return (comboBox.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "未選択";
     }
     #endregion
 }

--- a/WInUISample/Pages/AppStructurePage.xaml
+++ b/WInUISample/Pages/AppStructurePage.xaml
@@ -8,10 +8,77 @@
     mc:Ignorable="d">
 
     <ScrollViewer>
-        <StackPanel Spacing="12" Padding="32">
-            <TextBlock Text="アプリ構造" Style="{ThemeResource TitleTextBlockStyle}" />
-            <TextBlock Text="WinUI 3 アプリの起動、Window、Page、リソースの関係を整理する章です。" TextWrapping="Wrap" />
-            <TextBlock Text="この章の詳細なガイドは今後の Issue で実装します。" TextWrapping="Wrap" />
+        <StackPanel Style="{StaticResource GuideContentStackPanelStyle}">
+            <StackPanel Spacing="8">
+                <TextBlock Text="アプリ構造" Style="{ThemeResource TitleTextBlockStyle}" />
+                <TextBlock
+                    Text="WinUI 3 の App、Window、Frame、Page の役割を、WPF の App.xaml や Window と対応づけて確認します。"
+                    TextWrapping="Wrap" />
+            </StackPanel>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="起動からページ表示までの流れ" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <Grid ColumnSpacing="16" RowSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="160" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="App.OnLaunched" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="アプリの入口です。MainWindow を作成し、Activate で表示します。WPF の StartupUri に近い役割ですが、WinUI 3 ではコードで Window を生成します。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="MainWindow" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="アプリのシェルです。このサンプルでは NavigationView と Frame を持ち、画面全体の骨格を担当します。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Frame" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="Page を差し替える表示領域です。NavigationView の選択結果に応じて Frame.Navigate でページを読み込みます。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Page" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="3" Grid.Column="1" Text="章ごとの UI と説明を持つ画面単位です。Window とは分けて作ることで、ナビゲーションしやすい構成になります。" TextWrapping="Wrap" />
+                </Grid>
+            </StackPanel>
+
+            <Border Style="{StaticResource GuideCardBorderStyle}">
+                <StackPanel Spacing="10">
+                    <TextBlock Text="このサンプルでの構成" Style="{StaticResource GuideSubHeadingTextBlockStyle}" />
+                    <TextBlock
+                        Text="App.xaml.cs が MainWindow を起動し、MainWindow.xaml の NavigationView が章一覧を表示します。選択された章は MainWindow.xaml.cs の NavigateToPage で Page 型に変換され、ContentFrame に表示されます。"
+                        TextWrapping="Wrap" />
+                    <TextBlock
+                        Text="new MainWindow()&#x0a;_window.Activate()&#x0a;ContentFrame.Navigate(typeof(AppStructurePage))"
+                        Style="{StaticResource GuideCodeTextBlockStyle}" />
+                </StackPanel>
+            </Border>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="WPF との主な違い" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <Grid ColumnSpacing="16" RowSpacing="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="220" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="起動時の画面指定" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="WPF では StartupUri で Window を指定する構成が一般的です。WinUI 3 では OnLaunched で Window を明示的に作成します。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Window と Page の分担" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="Window はアプリの外枠、Page は差し替え可能な本文として考えると、WPF の Window 直配置より役割を分けやすくなります。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="リソースの配置" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="App.xaml にはテーマや共通スタイルを置き、Page 側では必要な UI と説明に集中します。" TextWrapping="Wrap" />
+                </Grid>
+            </StackPanel>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/WInUISample/Pages/DialogsPage.xaml
+++ b/WInUISample/Pages/DialogsPage.xaml
@@ -8,10 +8,63 @@
     mc:Ignorable="d">
 
     <ScrollViewer>
-        <StackPanel Spacing="12" Padding="32">
-            <TextBlock Text="ダイアログ" Style="{ThemeResource TitleTextBlockStyle}" />
-            <TextBlock Text="ContentDialog など、WinUI 3 のダイアログ表示を整理する章です。" TextWrapping="Wrap" />
-            <TextBlock Text="この章の詳細なガイドは今後の Issue で実装します。" TextWrapping="Wrap" />
+        <StackPanel Style="{StaticResource GuideContentStackPanelStyle}">
+            <StackPanel Spacing="8">
+                <TextBlock Text="ダイアログ" Style="{ThemeResource TitleTextBlockStyle}" />
+                <TextBlock
+                    Text="WPF の MessageBox から WinUI 3 の ContentDialog へ置き換えるときの考え方と実装手順を確認します。"
+                    TextWrapping="Wrap" />
+            </StackPanel>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="ContentDialog の基本" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <Grid ColumnSpacing="16" RowSpacing="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="170" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Title / Content" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="タイトルと本文を設定します。本文には文字列だけでなく、StackPanel などの UI も配置できます。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="ButtonText" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="Primary、Secondary、Close の各ボタンを必要に応じて設定します。戻り値は ContentDialogResult で確認できます。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="XamlRoot" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="WinUI 3 では、どの XAML ツリー上に表示するかを示すため、表示前に現在ページの XamlRoot を設定します。" TextWrapping="Wrap" />
+                </Grid>
+            </StackPanel>
+
+            <Border Style="{StaticResource GuideCardBorderStyle}">
+                <StackPanel Spacing="12">
+                    <TextBlock Text="表示サンプル" Style="{StaticResource GuideSubHeadingTextBlockStyle}" />
+                    <TextBlock
+                        Text="ボタンを押すと、このページの XamlRoot を使って ContentDialog を表示します。選択した結果は下に表示されます。"
+                        TextWrapping="Wrap" />
+                    <Button
+                        Content="ContentDialog を表示"
+                        Click="ShowDialogButton_Click" />
+                    <TextBlock
+                        x:Name="DialogResultTextBlock"
+                        Text="まだダイアログは表示していません。"
+                        TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="WPF MessageBox との違い" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <TextBlock
+                    Text="WPF の MessageBox.Show は同期的な確認に向いています。WinUI 3 の ContentDialog は非同期で表示し、アプリの XAML ツリーに紐づけて扱います。複雑な内容を表示したい場合は、Content に任意の UI を置ける点も大きな違いです。"
+                    TextWrapping="Wrap" />
+                <TextBlock
+                    Text="var result = await dialog.ShowAsync();"
+                    Style="{StaticResource GuideCodeTextBlockStyle}" />
+            </StackPanel>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/WInUISample/Pages/DialogsPage.xaml.cs
+++ b/WInUISample/Pages/DialogsPage.xaml.cs
@@ -1,4 +1,6 @@
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using System;
 
 namespace WinUISample.Pages;
 
@@ -14,6 +16,33 @@ public sealed partial class DialogsPage : Page
     public DialogsPage()
     {
         InitializeComponent();
+    }
+    #endregion
+
+    #region ShowDialogButton_Click : ContentDialog 表示ボタン押下時のイベントハンドラー
+    /// <summary>
+    /// ContentDialog 表示ボタン押下時のイベントハンドラー
+    /// </summary>
+    private async void ShowDialogButton_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new ContentDialog
+        {
+            Title = "ContentDialog のサンプル",
+            Content = "WinUI 3 では XamlRoot を設定して、現在のページ上にダイアログを表示します。",
+            PrimaryButtonText = "保存する",
+            SecondaryButtonText = "あとで",
+            CloseButtonText = "閉じる",
+            DefaultButton = ContentDialogButton.Primary,
+            XamlRoot = XamlRoot,
+        };
+
+        var result = await dialog.ShowAsync();
+        DialogResultTextBlock.Text = result switch
+        {
+            ContentDialogResult.Primary => "結果: Primary ボタンが選択されました。",
+            ContentDialogResult.Secondary => "結果: Secondary ボタンが選択されました。",
+            _ => "結果: ダイアログは閉じられました。",
+        };
     }
     #endregion
 }

--- a/WInUISample/Pages/LayoutPage.xaml
+++ b/WInUISample/Pages/LayoutPage.xaml
@@ -12,8 +12,108 @@
             <StackPanel Spacing="8">
                 <TextBlock Text="レイアウト" Style="{ThemeResource TitleTextBlockStyle}" />
                 <TextBlock
-                    Text="Grid、StackPanel、余白、配置、スクロール領域を、WPF との共通点と WinUI 3 での注意点に分けて確認します。"
+                    Text="Grid の行列、余白、配置を変えたときに、画面上の要素がどう移動するかを直接確認します。"
                     TextWrapping="Wrap" />
+            </StackPanel>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="レイアウトを直接切り替える" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <Grid ColumnSpacing="20" RowSpacing="16">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="260" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0" Spacing="12">
+                        <StackPanel Spacing="6">
+                            <TextBlock Text="配置パターン" FontWeight="SemiBold" />
+                            <ComboBox
+                                x:Name="LayoutModeComboBox"
+                                MinWidth="220"
+                                SelectionChanged="LayoutModeComboBox_SelectionChanged">
+                                <ComboBoxItem Content="横並び" Tag="Columns" />
+                                <ComboBoxItem Content="縦積み" Tag="Rows" />
+                                <ComboBoxItem Content="主従レイアウト" Tag="MasterDetail" />
+                            </ComboBox>
+                        </StackPanel>
+
+                        <StackPanel Spacing="6">
+                            <TextBlock Text="要素間の余白" FontWeight="SemiBold" />
+                            <Slider
+                                x:Name="ItemSpacingSlider"
+                                Minimum="0"
+                                Maximum="32"
+                                StepFrequency="2"
+                                ValueChanged="ItemSpacingSlider_ValueChanged" />
+                        </StackPanel>
+
+                        <StackPanel Spacing="6">
+                            <TextBlock Text="要素の横方向配置" FontWeight="SemiBold" />
+                            <ComboBox
+                                x:Name="ItemAlignmentComboBox"
+                                MinWidth="220"
+                                SelectionChanged="ItemAlignmentComboBox_SelectionChanged">
+                                <ComboBoxItem Content="左寄せ" Tag="Left" />
+                                <ComboBoxItem Content="中央寄せ" Tag="Center" />
+                                <ComboBoxItem Content="幅いっぱい" Tag="Stretch" />
+                            </ComboBox>
+                        </StackPanel>
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="1" Spacing="10">
+                        <Grid
+                            x:Name="LayoutPreviewGrid"
+                            MinHeight="220"
+                            ColumnSpacing="16"
+                            RowSpacing="16">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+
+                            <Border
+                                x:Name="LayoutItemOne"
+                                Grid.Column="0"
+                                MinHeight="88"
+                                Style="{StaticResource GuideCardBorderStyle}">
+                                <StackPanel Spacing="6">
+                                    <TextBlock Text="一覧" FontWeight="SemiBold" />
+                                    <TextBlock Text="1 つ目の領域" TextWrapping="Wrap" />
+                                </StackPanel>
+                            </Border>
+
+                            <Border
+                                x:Name="LayoutItemTwo"
+                                Grid.Column="1"
+                                MinHeight="88"
+                                Style="{StaticResource GuideCardBorderStyle}">
+                                <StackPanel Spacing="6">
+                                    <TextBlock Text="詳細" FontWeight="SemiBold" />
+                                    <TextBlock Text="選択内容を表示" TextWrapping="Wrap" />
+                                </StackPanel>
+                            </Border>
+
+                            <Border
+                                x:Name="LayoutItemThree"
+                                Grid.Column="2"
+                                MinHeight="88"
+                                Style="{StaticResource GuideCardBorderStyle}">
+                                <StackPanel Spacing="6">
+                                    <TextBlock Text="操作" FontWeight="SemiBold" />
+                                    <TextBlock Text="ボタンや補足情報" TextWrapping="Wrap" />
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+
+                        <TextBlock
+                            x:Name="LayoutResultTextBlock"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+                </Grid>
             </StackPanel>
 
             <StackPanel Spacing="12">

--- a/WInUISample/Pages/LayoutPage.xaml
+++ b/WInUISample/Pages/LayoutPage.xaml
@@ -8,10 +8,90 @@
     mc:Ignorable="d">
 
     <ScrollViewer>
-        <StackPanel Spacing="12" Padding="32">
-            <TextBlock Text="レイアウト" Style="{ThemeResource TitleTextBlockStyle}" />
-            <TextBlock Text="Grid、StackPanel、レスポンシブな配置などを整理する章です。" TextWrapping="Wrap" />
-            <TextBlock Text="この章の詳細なガイドは今後の Issue で実装します。" TextWrapping="Wrap" />
+        <StackPanel Style="{StaticResource GuideContentStackPanelStyle}">
+            <StackPanel Spacing="8">
+                <TextBlock Text="レイアウト" Style="{ThemeResource TitleTextBlockStyle}" />
+                <TextBlock
+                    Text="Grid、StackPanel、余白、配置、スクロール領域を、WPF との共通点と WinUI 3 での注意点に分けて確認します。"
+                    TextWrapping="Wrap" />
+            </StackPanel>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="Grid と StackPanel の使い分け" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <Grid ColumnSpacing="16" RowSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <Border Grid.Column="0" Style="{StaticResource GuideCardBorderStyle}">
+                        <StackPanel Spacing="10">
+                            <TextBlock Text="Grid" Style="{StaticResource GuideSubHeadingTextBlockStyle}" />
+                            <TextBlock Text="行と列で画面を分割し、ラベルと入力欄のように位置をそろえたい場面に向いています。" TextWrapping="Wrap" />
+                            <Grid ColumnSpacing="8" RowSpacing="8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="90" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="名前" FontWeight="SemiBold" />
+                                <TextBox Grid.Row="0" Grid.Column="1" PlaceholderText="山田 太郎" />
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="役割" FontWeight="SemiBold" />
+                                <TextBox Grid.Row="1" Grid.Column="1" PlaceholderText="開発者" />
+                            </Grid>
+                        </StackPanel>
+                    </Border>
+
+                    <Border Grid.Column="1" Style="{StaticResource GuideCardBorderStyle}">
+                        <StackPanel Spacing="10">
+                            <TextBlock Text="StackPanel" Style="{StaticResource GuideSubHeadingTextBlockStyle}" />
+                            <TextBlock Text="見出し、説明、操作ボタンを順に積むような読み物ページに向いています。" TextWrapping="Wrap" />
+                            <StackPanel Spacing="8">
+                                <TextBlock Text="手順 1: 章を選ぶ" />
+                                <TextBlock Text="手順 2: 説明を読む" />
+                                <TextBlock Text="手順 3: サンプルを試す" />
+                                <Button Content="サンプル操作" HorizontalAlignment="Left" />
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </StackPanel>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="余白と配置" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <Grid ColumnSpacing="16" RowSpacing="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="180" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Margin" FontWeight="SemiBold" />
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="要素の外側の余白です。周囲の要素との距離を調整します。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Padding" FontWeight="SemiBold" />
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="要素の内側の余白です。Border やコンテナー内の読みやすさを調整します。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Alignment" FontWeight="SemiBold" />
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="HorizontalAlignment と VerticalAlignment で、親領域内の位置を決めます。" TextWrapping="Wrap" />
+                </Grid>
+            </StackPanel>
+
+            <Border Style="{StaticResource GuideCardBorderStyle}">
+                <StackPanel Spacing="10">
+                    <TextBlock Text="スクロール領域を明示する" Style="{StaticResource GuideSubHeadingTextBlockStyle}" />
+                    <TextBlock
+                        Text="WinUI 3 でも WPF と同じく Grid や StackPanel は使えます。ただしウィンドウサイズや説明文の長さが変わるガイドページでは、Page の本文を ScrollViewer で包み、内容がはみ出しても読めるようにします。"
+                        TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/WInUISample/Pages/LayoutPage.xaml.cs
+++ b/WInUISample/Pages/LayoutPage.xaml.cs
@@ -1,3 +1,4 @@
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
 namespace WinUISample.Pages;
@@ -7,6 +8,8 @@ namespace WinUISample.Pages;
 /// </summary>
 public sealed partial class LayoutPage : Page
 {
+    private bool _isInitializing = true;
+
     #region Constructor
     /// <summary>
     /// コンストラクタ
@@ -14,6 +17,274 @@ public sealed partial class LayoutPage : Page
     public LayoutPage()
     {
         InitializeComponent();
+        InitializeLayoutControls();
+        _isInitializing = false;
+        ApplyLayoutPreview();
+    }
+    #endregion
+
+    #region InitializeLayoutControls : レイアウト操作コントロールを初期化
+    /// <summary>
+    /// レイアウト操作コントロールを初期化します。
+    /// </summary>
+    private void InitializeLayoutControls()
+    {
+        LayoutModeComboBox.SelectedIndex = 0;
+        ItemSpacingSlider.Value = 16;
+        ItemAlignmentComboBox.SelectedIndex = 2;
+    }
+    #endregion
+
+    #region LayoutModeComboBox_SelectionChanged : 配置パターン選択時のイベントハンドラー
+    /// <summary>
+    /// 配置パターン選択時のイベントハンドラー
+    /// </summary>
+    private void LayoutModeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isInitializing)
+        {
+            return;
+        }
+
+        ApplyLayoutPreview();
+    }
+    #endregion
+
+    #region ItemSpacingSlider_ValueChanged : 余白変更時のイベントハンドラー
+    /// <summary>
+    /// 余白変更時のイベントハンドラー
+    /// </summary>
+    private void ItemSpacingSlider_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+    {
+        if (_isInitializing)
+        {
+            return;
+        }
+
+        ApplySpacing();
+        UpdateLayoutResult();
+    }
+    #endregion
+
+    #region ItemAlignmentComboBox_SelectionChanged : 横方向配置選択時のイベントハンドラー
+    /// <summary>
+    /// 横方向配置選択時のイベントハンドラー
+    /// </summary>
+    private void ItemAlignmentComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isInitializing)
+        {
+            return;
+        }
+
+        ApplyItemAlignment();
+        UpdateLayoutResult();
+    }
+    #endregion
+
+    #region ApplyLayoutPreview : 選択されたレイアウトを適用
+    /// <summary>
+    /// 選択されたレイアウトをプレビューへ適用します。
+    /// </summary>
+    private void ApplyLayoutPreview()
+    {
+        ResetPreviewGrid();
+
+        switch (GetSelectedTag(LayoutModeComboBox))
+        {
+            case "Rows":
+                ConfigureRowsLayout();
+                break;
+
+            case "MasterDetail":
+                ConfigureMasterDetailLayout();
+                break;
+
+            default:
+                ConfigureColumnsLayout();
+                break;
+        }
+
+        ApplySpacing();
+        ApplyItemAlignment();
+        UpdateLayoutResult();
+    }
+    #endregion
+
+    #region ResetPreviewGrid : プレビューグリッドを初期化
+    /// <summary>
+    /// プレビューグリッドを初期化します。
+    /// </summary>
+    private void ResetPreviewGrid()
+    {
+        LayoutPreviewGrid.ColumnDefinitions.Clear();
+        LayoutPreviewGrid.RowDefinitions.Clear();
+
+        Grid.SetColumn(LayoutItemOne, 0);
+        Grid.SetColumn(LayoutItemTwo, 0);
+        Grid.SetColumn(LayoutItemThree, 0);
+        Grid.SetRow(LayoutItemOne, 0);
+        Grid.SetRow(LayoutItemTwo, 0);
+        Grid.SetRow(LayoutItemThree, 0);
+        Grid.SetColumnSpan(LayoutItemOne, 1);
+        Grid.SetColumnSpan(LayoutItemTwo, 1);
+        Grid.SetColumnSpan(LayoutItemThree, 1);
+        Grid.SetRowSpan(LayoutItemOne, 1);
+        Grid.SetRowSpan(LayoutItemTwo, 1);
+        Grid.SetRowSpan(LayoutItemThree, 1);
+    }
+    #endregion
+
+    #region ConfigureColumnsLayout : 横並びレイアウトを設定
+    /// <summary>
+    /// 横並びレイアウトを設定します。
+    /// </summary>
+    private void ConfigureColumnsLayout()
+    {
+        AddStarColumns(3);
+        AddStarRows(1);
+
+        Grid.SetColumn(LayoutItemOne, 0);
+        Grid.SetColumn(LayoutItemTwo, 1);
+        Grid.SetColumn(LayoutItemThree, 2);
+    }
+    #endregion
+
+    #region ConfigureRowsLayout : 縦積みレイアウトを設定
+    /// <summary>
+    /// 縦積みレイアウトを設定します。
+    /// </summary>
+    private void ConfigureRowsLayout()
+    {
+        AddStarColumns(1);
+        AddAutoRows(3);
+
+        Grid.SetRow(LayoutItemOne, 0);
+        Grid.SetRow(LayoutItemTwo, 1);
+        Grid.SetRow(LayoutItemThree, 2);
+    }
+    #endregion
+
+    #region ConfigureMasterDetailLayout : 主従レイアウトを設定
+    /// <summary>
+    /// 主従レイアウトを設定します。
+    /// </summary>
+    private void ConfigureMasterDetailLayout()
+    {
+        LayoutPreviewGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(2, GridUnitType.Star) });
+        LayoutPreviewGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(3, GridUnitType.Star) });
+        AddStarRows(2);
+
+        Grid.SetColumn(LayoutItemOne, 0);
+        Grid.SetRow(LayoutItemOne, 0);
+        Grid.SetRowSpan(LayoutItemOne, 2);
+
+        Grid.SetColumn(LayoutItemTwo, 1);
+        Grid.SetRow(LayoutItemTwo, 0);
+
+        Grid.SetColumn(LayoutItemThree, 1);
+        Grid.SetRow(LayoutItemThree, 1);
+    }
+    #endregion
+
+    #region ApplySpacing : 要素間の余白を適用
+    /// <summary>
+    /// 要素間の余白を適用します。
+    /// </summary>
+    private void ApplySpacing()
+    {
+        LayoutPreviewGrid.ColumnSpacing = ItemSpacingSlider.Value;
+        LayoutPreviewGrid.RowSpacing = ItemSpacingSlider.Value;
+    }
+    #endregion
+
+    #region ApplyItemAlignment : 要素の横方向配置を適用
+    /// <summary>
+    /// 要素の横方向配置を適用します。
+    /// </summary>
+    private void ApplyItemAlignment()
+    {
+        var alignment = GetSelectedTag(ItemAlignmentComboBox) switch
+        {
+            "Left" => HorizontalAlignment.Left,
+            "Center" => HorizontalAlignment.Center,
+            _ => HorizontalAlignment.Stretch,
+        };
+
+        foreach (var item in new[] { LayoutItemOne, LayoutItemTwo, LayoutItemThree })
+        {
+            item.HorizontalAlignment = alignment;
+            item.Width = alignment == HorizontalAlignment.Stretch ? double.NaN : 180;
+        }
+    }
+    #endregion
+
+    #region AddStarColumns : Star 幅の列を追加
+    /// <summary>
+    /// Star 幅の列を追加します。
+    /// </summary>
+    private void AddStarColumns(int count)
+    {
+        for (var index = 0; index < count; index++)
+        {
+            LayoutPreviewGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        }
+    }
+    #endregion
+
+    #region AddStarRows : Star 高さの行を追加
+    /// <summary>
+    /// Star 高さの行を追加します。
+    /// </summary>
+    private void AddStarRows(int count)
+    {
+        for (var index = 0; index < count; index++)
+        {
+            LayoutPreviewGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+        }
+    }
+    #endregion
+
+    #region AddAutoRows : Auto 高さの行を追加
+    /// <summary>
+    /// Auto 高さの行を追加します。
+    /// </summary>
+    private void AddAutoRows(int count)
+    {
+        for (var index = 0; index < count; index++)
+        {
+            LayoutPreviewGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        }
+    }
+    #endregion
+
+    #region UpdateLayoutResult : 現在のレイアウト状態表示を更新
+    /// <summary>
+    /// 現在のレイアウト状態表示を更新します。
+    /// </summary>
+    private void UpdateLayoutResult()
+    {
+        LayoutResultTextBlock.Text = $"現在のレイアウト: 配置 = {GetSelectedContent(LayoutModeComboBox)} / 余白 = {ItemSpacingSlider.Value:0}px / 横方向配置 = {GetSelectedContent(ItemAlignmentComboBox)}";
+    }
+    #endregion
+
+    #region GetSelectedTag : 選択項目のタグを取得
+    /// <summary>
+    /// 選択項目のタグを取得します。
+    /// </summary>
+    private static string? GetSelectedTag(ComboBox comboBox)
+    {
+        return (comboBox.SelectedItem as ComboBoxItem)?.Tag?.ToString();
+    }
+    #endregion
+
+    #region GetSelectedContent : 選択項目の表示名を取得
+    /// <summary>
+    /// 選択項目の表示名を取得します。
+    /// </summary>
+    private static string GetSelectedContent(ComboBox comboBox)
+    {
+        return (comboBox.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "未選択";
     }
     #endregion
 }

--- a/WInUISample/Pages/NavigationPage.xaml
+++ b/WInUISample/Pages/NavigationPage.xaml
@@ -8,10 +8,56 @@
     mc:Ignorable="d">
 
     <ScrollViewer>
-        <StackPanel Spacing="12" Padding="32">
-            <TextBlock Text="ナビゲーション" Style="{ThemeResource TitleTextBlockStyle}" />
-            <TextBlock Text="NavigationView と Frame を使った画面遷移を整理する章です。" TextWrapping="Wrap" />
-            <TextBlock Text="この章の詳細なガイドは今後の Issue で実装します。" TextWrapping="Wrap" />
+        <StackPanel Style="{StaticResource GuideContentStackPanelStyle}">
+            <StackPanel Spacing="8">
+                <TextBlock Text="ナビゲーション" Style="{ThemeResource TitleTextBlockStyle}" />
+                <TextBlock
+                    Text="NavigationView で章を選び、Frame に Page を表示する WinUI 3 の基本パターンを確認します。"
+                    TextWrapping="Wrap" />
+            </StackPanel>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="このアプリの遷移パターン" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <Grid ColumnSpacing="16" RowSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="180" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="NavigationViewItem" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="メニューに表示する章です。Content が画面上の文字、Tag が遷移先を識別するキーになります。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="SelectionChanged" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="ユーザーが章を選ぶとイベントが発生し、選択された NavigationViewItem を NavigateToPage に渡します。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Frame.Navigate" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="Tag に対応する Page 型を ContentFrame に表示します。同じページを選んだ場合は再遷移しないように現在の Page 型を確認します。" TextWrapping="Wrap" />
+                </Grid>
+            </StackPanel>
+
+            <Border Style="{StaticResource GuideCardBorderStyle}">
+                <StackPanel Spacing="10">
+                    <TextBlock Text="MainWindow の対応関係" Style="{StaticResource GuideSubHeadingTextBlockStyle}" />
+                    <TextBlock
+                        Text="NavigationViewItem.Tag = &quot;Dialogs&quot;&#x0a;Tag の値を typeof(DialogsPage) に変換&#x0a;ContentFrame.Navigate(typeof(DialogsPage))"
+                        Style="{StaticResource GuideCodeTextBlockStyle}" />
+                </StackPanel>
+            </Border>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="WPF から移るときの考え方" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <TextBlock
+                    Text="WPF では Button や MenuItem の Click イベントから個別に Frame.Navigate を呼ぶ構成もよく使われます。WinUI 3 では NavigationView をアプリのシェルに置き、選択処理を 1 か所に集約すると、メニューの追加やページ差し替えが追いやすくなります。"
+                    TextWrapping="Wrap" />
+                <TextBlock
+                    Text="このサンプルも MainWindow がナビゲーションを管理し、各 Page は本文とサンプル操作だけを担当する構成にしています。"
+                    TextWrapping="Wrap" />
+            </StackPanel>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/WInUISample/Pages/StylingPage.xaml
+++ b/WInUISample/Pages/StylingPage.xaml
@@ -8,10 +8,59 @@
     mc:Ignorable="d">
 
     <ScrollViewer>
-        <StackPanel Spacing="12" Padding="32">
-            <TextBlock Text="スタイリング" Style="{ThemeResource TitleTextBlockStyle}" />
-            <TextBlock Text="ThemeResource、Style、テンプレートなどを整理する章です。" TextWrapping="Wrap" />
-            <TextBlock Text="この章の詳細なガイドは今後の Issue で実装します。" TextWrapping="Wrap" />
+        <StackPanel Style="{StaticResource GuideContentStackPanelStyle}">
+            <StackPanel Spacing="8">
+                <TextBlock Text="スタイリング" Style="{ThemeResource TitleTextBlockStyle}" />
+                <TextBlock
+                    Text="ResourceDictionary、StaticResource、ThemeResource、標準スタイルの使い分けを、WPF との違いとあわせて確認します。"
+                    TextWrapping="Wrap" />
+            </StackPanel>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="リソースの使い分け" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <Grid ColumnSpacing="16" RowSpacing="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="190" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="ResourceDictionary" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="アプリ全体で共有する色、余白、Style をまとめます。このサンプルでは App.xaml にガイドページ共通のスタイルを置いています。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="StaticResource" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="起動後に値が変わらない前提のリソース参照に使います。独自スタイルや固定的なレイアウト値に向いています。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="ThemeResource" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="ライトテーマ、ダークテーマ、ハイコントラストなどテーマ変化に追従したい色や標準スタイルに使います。" TextWrapping="Wrap" />
+                </Grid>
+            </StackPanel>
+
+            <Border Style="{StaticResource GuideCardBorderStyle}">
+                <StackPanel Spacing="12">
+                    <TextBlock Text="共通スタイルの例" Style="{StaticResource GuideSubHeadingTextBlockStyle}" />
+                    <TextBlock
+                        Text="複数ページで同じ余白やカード表現を使う場合、各 Page に同じ値を直接書くより、App.xaml の Style にまとめると変更箇所を減らせます。"
+                        TextWrapping="Wrap" />
+                    <TextBlock
+                        Text="Style=&quot;{StaticResource GuideCardBorderStyle}&quot;&#x0a;Style=&quot;{StaticResource GuideSectionHeadingTextBlockStyle}&quot;"
+                        Style="{StaticResource GuideCodeTextBlockStyle}" />
+                </StackPanel>
+            </Border>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="WinUI 標準スタイルを活用する" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <TextBlock
+                    Text="TitleTextBlockStyle などの標準スタイルや、CardBackgroundFillColorDefaultBrush などのテーマブラシを使うと、Windows のテーマに合わせた見た目を保ちやすくなります。固定色を増やす前に、ThemeResource で表現できないかを確認します。"
+                    TextWrapping="Wrap" />
+                <TextBlock
+                    Text="WPF と同じように ResourceDictionary で見た目を共有できますが、WinUI 3 ではテーマリソースを前提にした標準コントロールの見た目を優先すると、ライト／ダークテーマで破綻しにくくなります。"
+                    TextWrapping="Wrap" />
+            </StackPanel>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/WInUISample/Pages/StylingPage.xaml
+++ b/WInUISample/Pages/StylingPage.xaml
@@ -7,13 +7,132 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
+    <Page.Resources>
+        <SolidColorBrush x:Key="StylePreviewNeutralBackgroundBrush" Color="#F8FAFC" />
+        <SolidColorBrush x:Key="StylePreviewNeutralForegroundBrush" Color="#1F2937" />
+        <SolidColorBrush x:Key="StylePreviewAccentBackgroundBrush" Color="#EAF2FF" />
+        <SolidColorBrush x:Key="StylePreviewAccentForegroundBrush" Color="#123B6D" />
+        <SolidColorBrush x:Key="StylePreviewActionBackgroundBrush" Color="#2563EB" />
+        <SolidColorBrush x:Key="StylePreviewActionForegroundBrush" Color="White" />
+
+        <Style x:Key="PreviewStandardTitleTextBlockStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="20" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{StaticResource StylePreviewNeutralForegroundBrush}" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+
+        <Style x:Key="PreviewAccentTitleTextBlockStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="24" />
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="Foreground" Value="{StaticResource StylePreviewAccentForegroundBrush}" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+
+        <Style x:Key="PreviewCompactTitleTextBlockStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="16" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{StaticResource StylePreviewNeutralForegroundBrush}" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+
+        <Style x:Key="PreviewStandardButtonStyle" TargetType="Button">
+            <Setter Property="MinWidth" Value="112" />
+            <Setter Property="Padding" Value="12,6" />
+            <Setter Property="CornerRadius" Value="4" />
+        </Style>
+
+        <Style x:Key="PreviewAccentButtonStyle" TargetType="Button">
+            <Setter Property="MinWidth" Value="128" />
+            <Setter Property="Padding" Value="18,8" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Background" Value="{StaticResource StylePreviewActionBackgroundBrush}" />
+            <Setter Property="Foreground" Value="{StaticResource StylePreviewActionForegroundBrush}" />
+        </Style>
+
+        <Style x:Key="PreviewCompactButtonStyle" TargetType="Button">
+            <Setter Property="MinWidth" Value="88" />
+            <Setter Property="Padding" Value="8,4" />
+            <Setter Property="CornerRadius" Value="2" />
+            <Setter Property="FontSize" Value="12" />
+        </Style>
+    </Page.Resources>
+
     <ScrollViewer>
         <StackPanel Style="{StaticResource GuideContentStackPanelStyle}">
             <StackPanel Spacing="8">
                 <TextBlock Text="スタイリング" Style="{ThemeResource TitleTextBlockStyle}" />
                 <TextBlock
-                    Text="ResourceDictionary、StaticResource、ThemeResource、標準スタイルの使い分けを、WPF との違いとあわせて確認します。"
+                    Text="Style を切り替えたときに、余白、文字サイズ、色、角丸、枠線が UI にどう反映されるかを直接確認します。"
                     TextWrapping="Wrap" />
+            </StackPanel>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="スタイルを直接切り替える" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <Grid ColumnSpacing="20" RowSpacing="16">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="260" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0" Spacing="12">
+                        <StackPanel Spacing="6">
+                            <TextBlock Text="スタイルプリセット" FontWeight="SemiBold" />
+                            <ComboBox
+                                x:Name="StylePresetComboBox"
+                                MinWidth="220"
+                                SelectionChanged="StylePresetComboBox_SelectionChanged">
+                                <ComboBoxItem Content="標準" Tag="Standard" />
+                                <ComboBoxItem Content="強調" Tag="Accent" />
+                                <ComboBoxItem Content="コンパクト" Tag="Compact" />
+                            </ComboBox>
+                        </StackPanel>
+
+                        <StackPanel Spacing="6">
+                            <TextBlock Text="カードの角丸" FontWeight="SemiBold" />
+                            <Slider
+                                x:Name="CornerRadiusSlider"
+                                Minimum="0"
+                                Maximum="24"
+                                StepFrequency="1"
+                                ValueChanged="CornerRadiusSlider_ValueChanged" />
+                        </StackPanel>
+
+                        <ToggleSwitch
+                            x:Name="BorderToggleSwitch"
+                            Header="カードの枠線"
+                            Toggled="BorderToggleSwitch_Toggled" />
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="1" Spacing="10">
+                        <Border
+                            x:Name="StylePreviewCard"
+                            Padding="18"
+                            CornerRadius="8"
+                            Background="{StaticResource StylePreviewNeutralBackgroundBrush}"
+                            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                            BorderThickness="1">
+                            <StackPanel Spacing="12">
+                                <TextBlock
+                                    x:Name="StylePreviewTitleTextBlock"
+                                    Text="プレビューカード"
+                                    Style="{StaticResource PreviewStandardTitleTextBlockStyle}" />
+                                <TextBlock
+                                    x:Name="StylePreviewBodyTextBlock"
+                                    Text="プリセットを変えると、この見出し、本文、ボタン、カード余白のスタイルが同時に変わります。"
+                                    TextWrapping="Wrap" />
+                                <Button
+                                    x:Name="StylePreviewButton"
+                                    Content="操作する"
+                                    HorizontalAlignment="Left"
+                                    Style="{StaticResource PreviewStandardButtonStyle}" />
+                            </StackPanel>
+                        </Border>
+                        <TextBlock
+                            x:Name="StyleResultTextBlock"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+                </Grid>
             </StackPanel>
 
             <StackPanel Spacing="12">

--- a/WInUISample/Pages/StylingPage.xaml.cs
+++ b/WInUISample/Pages/StylingPage.xaml.cs
@@ -1,4 +1,6 @@
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 
 namespace WinUISample.Pages;
 
@@ -7,6 +9,8 @@ namespace WinUISample.Pages;
 /// </summary>
 public sealed partial class StylingPage : Page
 {
+    private bool _isInitializing = true;
+
     #region Constructor
     /// <summary>
     /// コンストラクタ
@@ -14,6 +18,157 @@ public sealed partial class StylingPage : Page
     public StylingPage()
     {
         InitializeComponent();
+        InitializeStyleControls();
+        _isInitializing = false;
+        ApplySelectedStyle();
+    }
+    #endregion
+
+    #region InitializeStyleControls : スタイル操作コントロールを初期化
+    /// <summary>
+    /// スタイル操作コントロールを初期化します。
+    /// </summary>
+    private void InitializeStyleControls()
+    {
+        StylePresetComboBox.SelectedIndex = 0;
+        CornerRadiusSlider.Value = 8;
+        BorderToggleSwitch.IsOn = true;
+    }
+    #endregion
+
+    #region StylePresetComboBox_SelectionChanged : スタイルプリセット選択時のイベントハンドラー
+    /// <summary>
+    /// スタイルプリセット選択時のイベントハンドラー
+    /// </summary>
+    private void StylePresetComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isInitializing)
+        {
+            return;
+        }
+
+        ApplySelectedStyle();
+    }
+    #endregion
+
+    #region CornerRadiusSlider_ValueChanged : 角丸変更時のイベントハンドラー
+    /// <summary>
+    /// 角丸変更時のイベントハンドラー
+    /// </summary>
+    private void CornerRadiusSlider_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+    {
+        if (_isInitializing)
+        {
+            return;
+        }
+
+        StylePreviewCard.CornerRadius = new CornerRadius(e.NewValue);
+        UpdateStyleResult();
+    }
+    #endregion
+
+    #region BorderToggleSwitch_Toggled : 枠線切り替え時のイベントハンドラー
+    /// <summary>
+    /// 枠線切り替え時のイベントハンドラー
+    /// </summary>
+    private void BorderToggleSwitch_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (_isInitializing)
+        {
+            return;
+        }
+
+        StylePreviewCard.BorderThickness = BorderToggleSwitch.IsOn ? new Thickness(1) : new Thickness(0);
+        UpdateStyleResult();
+    }
+    #endregion
+
+    #region ApplySelectedStyle : 選択されたスタイルを適用
+    /// <summary>
+    /// 選択されたスタイルをプレビューへ適用します。
+    /// </summary>
+    private void ApplySelectedStyle()
+    {
+        switch (GetSelectedTag(StylePresetComboBox))
+        {
+            case "Accent":
+                StylePreviewCard.Padding = new Thickness(24);
+                StylePreviewCard.Background = GetBrushResource("StylePreviewAccentBackgroundBrush");
+                StylePreviewTitleTextBlock.Style = GetStyleResource("PreviewAccentTitleTextBlockStyle");
+                StylePreviewBodyTextBlock.FontSize = 15;
+                StylePreviewButton.Style = GetStyleResource("PreviewAccentButtonStyle");
+                break;
+
+            case "Compact":
+                StylePreviewCard.Padding = new Thickness(12);
+                StylePreviewCard.Background = GetBrushResource("StylePreviewNeutralBackgroundBrush");
+                StylePreviewTitleTextBlock.Style = GetStyleResource("PreviewCompactTitleTextBlockStyle");
+                StylePreviewBodyTextBlock.FontSize = 13;
+                StylePreviewButton.Style = GetStyleResource("PreviewCompactButtonStyle");
+                break;
+
+            default:
+                StylePreviewCard.Padding = new Thickness(18);
+                StylePreviewCard.Background = GetBrushResource("StylePreviewNeutralBackgroundBrush");
+                StylePreviewTitleTextBlock.Style = GetStyleResource("PreviewStandardTitleTextBlockStyle");
+                StylePreviewBodyTextBlock.FontSize = 14;
+                StylePreviewButton.Style = GetStyleResource("PreviewStandardButtonStyle");
+                break;
+        }
+
+        StylePreviewCard.CornerRadius = new CornerRadius(CornerRadiusSlider.Value);
+        StylePreviewCard.BorderThickness = BorderToggleSwitch.IsOn ? new Thickness(1) : new Thickness(0);
+        UpdateStyleResult();
+    }
+    #endregion
+
+    #region UpdateStyleResult : 現在のスタイル状態表示を更新
+    /// <summary>
+    /// 現在のスタイル状態表示を更新します。
+    /// </summary>
+    private void UpdateStyleResult()
+    {
+        StyleResultTextBlock.Text = $"現在のスタイル: プリセット = {GetSelectedContent(StylePresetComboBox)} / 角丸 = {CornerRadiusSlider.Value:0}px / 枠線 = {(BorderToggleSwitch.IsOn ? "あり" : "なし")}";
+    }
+    #endregion
+
+    #region GetSelectedTag : 選択項目のタグを取得
+    /// <summary>
+    /// 選択項目のタグを取得します。
+    /// </summary>
+    private static string? GetSelectedTag(ComboBox comboBox)
+    {
+        return (comboBox.SelectedItem as ComboBoxItem)?.Tag?.ToString();
+    }
+    #endregion
+
+    #region GetSelectedContent : 選択項目の表示名を取得
+    /// <summary>
+    /// 選択項目の表示名を取得します。
+    /// </summary>
+    private static string GetSelectedContent(ComboBox comboBox)
+    {
+        return (comboBox.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "未選択";
+    }
+    #endregion
+
+    #region GetBrushResource : ブラシリソースを取得
+    /// <summary>
+    /// ブラシリソースを取得します。
+    /// </summary>
+    private Brush GetBrushResource(string key)
+    {
+        return (Brush)Resources[key];
+    }
+    #endregion
+
+    #region GetStyleResource : スタイルリソースを取得
+    /// <summary>
+    /// スタイルリソースを取得します。
+    /// </summary>
+    private Style GetStyleResource(string key)
+    {
+        return (Style)Resources[key];
     }
     #endregion
 }


### PR DESCRIPTION
WPF 経験者向け WinUI 3 ガイドの Issue #11〜#16 の実装ページを追加します。

## 変更内容
- アプリ構造、ナビゲーション、ダイアログ、レイアウト、スタイリング、アプリ外観ページのプレースホルダーを実装
- ガイドページ共通の見出し、カード、コード表示スタイルを App.xaml に追加
- ダイアログページで ContentDialog を表示し、選択結果を画面に反映
- App.xaml.cs のテンプレート由来コメントを日本語化し、未使用 using を整理

## 確認
- `dotnet build .\WinUISample.slnx -p:Platform=x64 --no-restore --verbosity minimal`

Closes #11
Closes #12
Closes #13
Closes #14
Closes #15
Closes #16