### PR TITLE
Add ItemsControls guide

### DIFF
--- a/WInUISample/MainWindow.xaml
+++ b/WInUISample/MainWindow.xaml
@@ -43,6 +43,10 @@
                 Icon="ViewAll"
                 Tag="Layout" />
             <NavigationViewItem
+                Content="ItemsControls"
+                Icon="List"
+                Tag="ItemsControls" />
+            <NavigationViewItem
                 Content="スタイリング"
                 Icon="Edit"
                 Tag="Styling" />

--- a/WInUISample/MainWindow.xaml.cs
+++ b/WInUISample/MainWindow.xaml.cs
@@ -44,6 +44,7 @@ namespace WinUISample
                 "Navigation" => typeof(NavigationPage),
                 "Dialogs" => typeof(DialogsPage),
                 "Layout" => typeof(LayoutPage),
+                "ItemsControls" => typeof(ItemsControlsPage),
                 "Styling" => typeof(StylingPage),
                 "AppAppearance" => typeof(AppAppearancePage),
                 _ => typeof(GettingStartedPage),

--- a/WInUISample/Pages/ItemsControlsPage.xaml
+++ b/WInUISample/Pages/ItemsControlsPage.xaml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WinUISample.Pages.ItemsControlsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <ScrollViewer>
+        <StackPanel Style="{StaticResource GuideContentStackPanelStyle}">
+            <StackPanel Spacing="8">
+                <TextBlock Text="ItemsControls" Style="{ThemeResource TitleTextBlockStyle}" />
+                <TextBlock
+                    Text="ListView、GridView、ItemsRepeater の役割を整理し、ItemsSource と DataTemplate でコレクションを画面へ表示する基本を確認します。"
+                    TextWrapping="Wrap" />
+            </StackPanel>
+
+            <Border Style="{StaticResource GuideCardBorderStyle}">
+                <StackPanel Spacing="14">
+                    <StackPanel Spacing="6">
+                        <TextBlock Text="ListView の ItemsSource / DataTemplate / 選択" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                        <TextBlock
+                            Text="ListView は選択、キーボード操作、スクロール、仮想化をまとめて扱える一覧コントロールです。WPF の ListBox / ListView と同じく ItemsSource にコレクションを渡し、DataTemplate で 1 行分の見た目を定義します。"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+
+                    <Grid ColumnSpacing="20" RowSpacing="16">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="320" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel Grid.Column="0" Spacing="10">
+                            <ToggleSwitch
+                                x:Name="EmptyStateToggleSwitch"
+                                Header="空状態を確認する"
+                                OffContent="サンプル項目を表示"
+                                OnContent="ItemsSource を空にする"
+                                Toggled="EmptyStateToggleSwitch_Toggled" />
+
+                            <ListView
+                                x:Name="ItemsSamplesListView"
+                                MaxHeight="360"
+                                ItemsSource="{x:Bind VisibleListSamples, Mode=OneWay}"
+                                SelectionChanged="ItemsSamplesListView_SelectionChanged"
+                                SelectionMode="Single">
+                                <ListView.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Padding="8">
+                                            <StackPanel Spacing="4">
+                                                <TextBlock Text="{Binding Title}" FontWeight="SemiBold" TextWrapping="Wrap" />
+                                                <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" />
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ListView.ItemTemplate>
+                            </ListView>
+
+                            <Border
+                                x:Name="EmptyStateBorder"
+                                Padding="16"
+                                Visibility="Collapsed"
+                                Style="{StaticResource GuideCardBorderStyle}">
+                                <StackPanel Spacing="6">
+                                    <TextBlock Text="表示できる項目がありません" FontWeight="SemiBold" TextWrapping="Wrap" />
+                                    <TextBlock
+                                        Text="WinUI 3 の ListView 自体に空状態ビューはないため、ItemsSource の件数に応じて補助 UI の Visibility を切り替えます。"
+                                        TextWrapping="Wrap" />
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+
+                        <StackPanel Grid.Column="1" Spacing="12">
+                            <Border Style="{StaticResource GuideCardBorderStyle}">
+                                <StackPanel Spacing="8">
+                                    <TextBlock Text="選択結果" Style="{StaticResource GuideSubHeadingTextBlockStyle}" />
+                                    <TextBlock
+                                        x:Name="SelectionResultTextBlock"
+                                        TextWrapping="Wrap" />
+                                </StackPanel>
+                            </Border>
+
+                            <Border Style="{StaticResource GuideCardBorderStyle}">
+                                <StackPanel Spacing="8">
+                                    <TextBlock Text="実装の流れ" Style="{StaticResource GuideSubHeadingTextBlockStyle}" />
+                                    <TextBlock
+                                        Text="ObservableCollection を ItemsSource に設定&#x0a;DataTemplate で 1 項目分の表示を定義&#x0a;SelectionChanged で選択項目を取り出して詳細を更新&#x0a;コレクションが空なら別の空状態 UI を表示"
+                                        Style="{StaticResource GuideCodeTextBlockStyle}" />
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="GridView はカードやタイルに向いた一覧" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <TextBlock
+                    Text="同じ ItemsSource / DataTemplate の考え方で、横方向にカードを並べたい場合は GridView を使います。写真、製品カード、設定タイルのように、選択可能なカード一覧を作る場面に向いています。"
+                    TextWrapping="Wrap" />
+
+                <GridView
+                    MaxHeight="260"
+                    ItemsSource="{x:Bind TileSamples, Mode=OneWay}"
+                    IsItemClickEnabled="False"
+                    SelectionMode="None">
+                    <GridView.ItemTemplate>
+                        <DataTemplate>
+                            <Border
+                                Width="220"
+                                MinHeight="120"
+                                Margin="4"
+                                Style="{StaticResource GuideCardBorderStyle}">
+                                <StackPanel Spacing="8">
+                                    <TextBlock Text="{Binding Title}" Style="{StaticResource GuideSubHeadingTextBlockStyle}" />
+                                    <TextBlock Text="{Binding Summary}" TextWrapping="Wrap" />
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </GridView.ItemTemplate>
+                </GridView>
+            </StackPanel>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="ListView / GridView / ItemsRepeater の使い分け" Style="{StaticResource GuideSectionHeadingTextBlockStyle}" />
+                <Grid ColumnSpacing="16" RowSpacing="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="170" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="ListView" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="縦方向の一覧、単一選択や複数選択、詳細表示との連動に向いています。通常の業務アプリの一覧はまず ListView を候補にします。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="GridView" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="カードやタイルを折り返し配置する一覧に向いています。ListView と同じく選択や項目コンテナーを持つため、画像一覧や設定タイルを作りやすいです。" TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="ItemsRepeater" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="軽量な繰り返し表示や独自レイアウトを組むための構成要素です。選択、既定の項目 UI、スクロール領域は内蔵しないため、通常の一覧選択では ListView / GridView を優先します。" TextWrapping="Wrap" />
+                </Grid>
+            </StackPanel>
+
+            <Border Style="{StaticResource GuideCardBorderStyle}">
+                <StackPanel Spacing="10">
+                    <TextBlock Text="大量データで気を付けること" Style="{StaticResource GuideSubHeadingTextBlockStyle}" />
+                    <TextBlock Text="• 大量データでは仮想化が効く ListView / GridView を優先します。" TextWrapping="Wrap" />
+                    <TextBlock Text="• DataTemplate の中に重いレイアウトや過剰なバインディングを入れすぎないようにします。" TextWrapping="Wrap" />
+                    <TextBlock Text="• 単一選択、複数選択、未選択を許可するかは画面要件から先に決めます。" TextWrapping="Wrap" />
+                    <TextBlock Text="• 列の並べ替えや表形式データが主目的なら、CommunityToolkit の DataGrid など別コントロールも検討します。" TextWrapping="Wrap" />
+                    <TextBlock Text="• ComboBox の固定候補はフォーム入力の選択肢として扱い、コレクション表示の説明は ListView / GridView を中心にします。" TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/WInUISample/Pages/ItemsControlsPage.xaml.cs
+++ b/WInUISample/Pages/ItemsControlsPage.xaml.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace WinUISample.Pages;
+
+/// <summary>
+/// ItemsControls 章のページです。
+/// </summary>
+public sealed partial class ItemsControlsPage : Page
+{
+    private readonly IReadOnlyList<ItemsControlSample> _allListSamples =
+    [
+        new(
+            "ItemsSource",
+            "画面に表示するコレクションを ListView に渡します。",
+            "WPF と同じく ItemsSource に IEnumerable を渡せます。更新通知が必要な場合は ObservableCollection を使います。",
+            "WinUI 3 でも UI スレッド上でコレクションを更新する前提は変わりません。"),
+        new(
+            "DataTemplate",
+            "1 件分の表示を XAML で定義します。",
+            "WPF の DataTemplate と近い考え方ですが、WinUI 3 の標準スタイルや余白に合わせるとアプリ全体の見た目がそろいます。",
+            "テンプレート内の要素数が増えるほどスクロール時の負荷も増えます。"),
+        new(
+            "SelectionChanged",
+            "選択された項目を取り出して詳細表示へ反映します。",
+            "ListBox / ListView の選択イベントに近い使い方です。複数選択では SelectedItems を確認します。",
+            "未選択を許可する画面では null の扱いも UI 表示として設計します。"),
+    ];
+
+    /// <summary>
+    /// ListView に表示するサンプル項目です。
+    /// </summary>
+    public ObservableCollection<ItemsControlSample> VisibleListSamples { get; } = [];
+
+    /// <summary>
+    /// GridView に表示するタイル項目です。
+    /// </summary>
+    public IReadOnlyList<ItemsControlTileSample> TileSamples { get; } =
+    [
+        new("ListView", "縦方向の一覧と選択に向いています。"),
+        new("GridView", "カードや画像をタイル状に並べる一覧に向いています。"),
+        new("ItemsRepeater", "選択 UI を持たない軽量な繰り返し表示に向いています。"),
+    ];
+
+    #region Constructor
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    public ItemsControlsPage()
+    {
+        InitializeComponent();
+        RestoreListSamples();
+        ItemsSamplesListView.SelectedIndex = 0;
+        UpdateEmptyState();
+        UpdateSelectionResult();
+    }
+    #endregion
+
+    #region EmptyStateToggleSwitch_Toggled : 空状態切り替え時のイベントハンドラー
+    /// <summary>
+    /// 空状態切り替え時のイベントハンドラー
+    /// </summary>
+    private void EmptyStateToggleSwitch_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (EmptyStateToggleSwitch.IsOn)
+        {
+            VisibleListSamples.Clear();
+        }
+        else
+        {
+            RestoreListSamples();
+            ItemsSamplesListView.SelectedIndex = 0;
+        }
+
+        UpdateEmptyState();
+        UpdateSelectionResult();
+    }
+    #endregion
+
+    #region ItemsSamplesListView_SelectionChanged : サンプル選択時のイベントハンドラー
+    /// <summary>
+    /// サンプル選択時のイベントハンドラー
+    /// </summary>
+    private void ItemsSamplesListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        UpdateSelectionResult();
+    }
+    #endregion
+
+    #region RestoreListSamples : ListView のサンプル項目を復元
+    /// <summary>
+    /// ListView のサンプル項目を復元します。
+    /// </summary>
+    private void RestoreListSamples()
+    {
+        VisibleListSamples.Clear();
+
+        foreach (var sample in _allListSamples)
+        {
+            VisibleListSamples.Add(sample);
+        }
+    }
+    #endregion
+
+    #region UpdateEmptyState : 空状態表示を更新
+    /// <summary>
+    /// 空状態表示を更新します。
+    /// </summary>
+    private void UpdateEmptyState()
+    {
+        var isEmpty = VisibleListSamples.Count == 0;
+        EmptyStateBorder.Visibility = isEmpty ? Visibility.Visible : Visibility.Collapsed;
+        ItemsSamplesListView.Visibility = isEmpty ? Visibility.Collapsed : Visibility.Visible;
+    }
+    #endregion
+
+    #region UpdateSelectionResult : 選択結果表示を更新
+    /// <summary>
+    /// 選択結果表示を更新します。
+    /// </summary>
+    private void UpdateSelectionResult()
+    {
+        if (ItemsSamplesListView.SelectedItem is not ItemsControlSample selectedSample)
+        {
+            SelectionResultTextBlock.Text = "項目が選択されていません。ItemsSource が空のときは、一覧とは別に空状態 UI を表示します。";
+            return;
+        }
+
+        SelectionResultTextBlock.Text = $"{selectedSample.Title}\n{selectedSample.WpfComparison}\n注意点: {selectedSample.Note}";
+    }
+    #endregion
+}
+
+/// <summary>
+/// ListView の説明用サンプル項目です。
+/// </summary>
+public sealed class ItemsControlSample
+{
+    /// <summary>
+    /// 項目名です。
+    /// </summary>
+    public string Title { get; set; }
+
+    /// <summary>
+    /// 一覧に表示する概要です。
+    /// </summary>
+    public string Summary { get; set; }
+
+    /// <summary>
+    /// WPF 経験者向けの比較説明です。
+    /// </summary>
+    public string WpfComparison { get; set; }
+
+    /// <summary>
+    /// 実装時の注意点です。
+    /// </summary>
+    public string Note { get; set; }
+
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    public ItemsControlSample(string title, string summary, string wpfComparison, string note)
+    {
+        Title = title;
+        Summary = summary;
+        WpfComparison = wpfComparison;
+        Note = note;
+    }
+}
+
+/// <summary>
+/// GridView の説明用タイル項目です。
+/// </summary>
+public sealed class ItemsControlTileSample
+{
+    /// <summary>
+    /// タイル名です。
+    /// </summary>
+    public string Title { get; set; }
+
+    /// <summary>
+    /// タイルに表示する概要です。
+    /// </summary>
+    public string Summary { get; set; }
+
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    public ItemsControlTileSample(string title, string summary)
+    {
+        Title = title;
+        Summary = summary;
+    }
+}


### PR DESCRIPTION
ItemsControls 系コントロールのガイド章を追加します。

- `ItemsControlsPage` を追加し、`ListView` の `ItemsSource` / `DataTemplate` / 選択結果 / 空状態切り替えを確認できるサンプルを実装
- `GridView` のカード表示サンプルと `ItemsRepeater` との使い分け説明を追加
- 左ナビゲーションから新章へ遷移できるよう `MainWindow` にメニューと Tag 対応を追加

Fixes #20